### PR TITLE
changing link from 2_secondsprint to 3_secondsprint

### DIFF
--- a/docs/_data/this_week.yaml
+++ b/docs/_data/this_week.yaml
@@ -4,7 +4,7 @@ projects:
 - date: Wed Sep 20
   deadline: Due Thu October 5 @ 11:59pm
   end_date: 2023-10-06 00:00:00
-  link: /projects/P2/2_secondsprint
+  link: /projects/P2/3_secondsprint
   name: Project 2C
   numDays: 12
 


### PR DESCRIPTION
The current link on the main page does not work for Project 2C. 

<img width="578" alt="image" src="https://github.com/CMU-17313Q/CMU-17313Q.github.io/assets/67548058/82d778a2-4a73-4e29-a5a7-ab3b72066b12">


Here, I am changing this link from 2_secondsprint to 3_secondsprint matching the `3_secondsprint.md` file name.


Please review this code @EduardoFF @Nour-Ali 