### PR TITLE
Add P5 to Sidebar

### DIFF
--- a/docs/projects/P5/1_projectcheck.md
+++ b/docs/projects/P5/1_projectcheck.md
@@ -4,7 +4,7 @@
 
 **Project & Task Selection** – 80 points
 
-- [Project Selectiion](#open-source-project-selection) - enter project name and URL in the spreadsheet by  Sunday, November 24th 11:59 pm
+- [Project Selection](#open-source-project-selection) - enter project name and URL in the spreadsheet by  Sunday, November 24th 11:59 pm
 - [Task Selection Checkpoint Presentation](#checkpoint-presentation-80-pts) – slides and video recording due Thursday, November 28th, 11:59pm
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,10 +83,10 @@ nav:
       #     - "Deployment Instructions": projects/P3/deployment.md
        - "Project 4: Architecting an LLM Integration":
            - projects/P4/index.md
-      # - "Project 5: Open Source Excursion":
-      #     - projects/P5/index.md
-      #     - "5A Project and Task Selection": projects/P5/1_projectcheck.md
-      #     - "5B Project Presentations, Final Report, and Reflections": projects/P5/2_projectfinal.md
+       - "Project 5: Open Source Excursion":
+          - projects/P5/index.md
+          - "5A Project and Task Selection": projects/P5/1_projectcheck.md
+          - "5B & C Project Presentations, Final Report, and Reflections": projects/P5/2_projectfinal.md
   - Recitations:
       #recitations/index.md # Dummy home page; remove once we start adding recitations below
        - Recitation 1 - Git & GitHub: recitations/reci1-github.md


### PR DESCRIPTION
This adds links to P5 in the sidebar of the Projects page. It also corrects a minor spelling mistake in P5A.

<img width="244" alt="image" src="https://github.com/user-attachments/assets/a66ab65e-5d9e-4efe-8f3d-6c84806474d9">

The UI changes have been tested in a locally running instance of the website.

Files Changed:
- mkdocs.yml
- docs/projects/P5/1_projectcheck.md